### PR TITLE
Configurable hotbar slots

### DIFF
--- a/Core.cpk/Scripts/Characters/State/PlayerCharacterPrivateState.cs
+++ b/Core.cpk/Scripts/Characters/State/PlayerCharacterPrivateState.cs
@@ -154,7 +154,7 @@
 
             this.ContainerHotbar ??= serverItemsService.CreateContainer<ItemsContainerCharacterHotbar>(
                 character,
-                slotsCount: 10);
+                slotsCount: PlayerConstants.HotbarSlotsCount);
 
             this.CraftingQueue ??= new CharacterCraftingQueue();
             this.Skills ??= new PlayerCharacterSkills();

--- a/Core.cpk/Scripts/Characters/State/PlayerConstants.cs
+++ b/Core.cpk/Scripts/Characters/State/PlayerConstants.cs
@@ -7,5 +7,10 @@
         /// Please note that it doesn't apply to the already registered players (their inventory container is already created).
         /// </summary>
         public const int InventorySlotsCount = 40;
+        /// <summary>
+        /// The number of the hotbar slots is configured here.
+        /// Please note that it doesn't apply to the already registered players (their hotbar container is already created).
+        /// </summary>
+        public const int HotbarSlotsCount = 10;
     }
 }

--- a/Core.cpk/Scripts/Characters/State/PlayerConstants.cs
+++ b/Core.cpk/Scripts/Characters/State/PlayerConstants.cs
@@ -10,6 +10,7 @@
         /// <summary>
         /// The number of the hotbar slots is configured here.
         /// Please note that it doesn't apply to the already registered players (their hotbar container is already created).
+        /// Also note if this value is odd then it will create a graphical bug in the display of the hotbar. See https://i.imgur.com/Dl6sRBi.png
         /// </summary>
         public const int HotbarSlotsCount = 10;
     }

--- a/Core.cpk/Scripts/ClientComponents/InputListeners/ClientComponentHotBarHelper.cs
+++ b/Core.cpk/Scripts/ClientComponents/InputListeners/ClientComponentHotBarHelper.cs
@@ -140,6 +140,11 @@
                 // the key was pressed
                 var hotbarSlotId = pair.Value;
 
+                if (hotbarSlotId >= ClientHotbarSelectedItemManager.ContainerHotbar.SlotsCount)
+                {
+                    break;
+                }
+
                 if (Input.IsKeyHeld(InputKey.Control, evenIfHandled: true)
                     || Input.IsKeyHeld(InputKey.Alt,  evenIfHandled: true))
                 {


### PR DESCRIPTION
This PR adds the ability to edit the number of default hotbar slots for a player. This does also handle trying to switch to a hotbar slot that shouldn't exist.

## Known Issues
This is documented in the comment for the constant but if the number of hotbar slots is set to an odd number then the hotbar divider will appear in the middle of a slot. I'm not familiar with XAML so I don't know a fix for this. I was only able to find that the divider comes from [Core.cpk/UI/Controls/Game/HUD/HUDItemsHotbarControl.xaml#21](https://github.com/AtomicTorchStudio/CryoFall/blob/master/Core.cpk/UI/Controls/Game/HUD/HUDItemsHotbarControl.xaml#L21)

![image](https://user-images.githubusercontent.com/11802285/117706632-8dae7500-b19b-11eb-9632-adcc91ca20c6.png)
